### PR TITLE
translate: MMC->MNC

### DIFF
--- a/luci/luci-app-qmodem/po/zh-cn/qmodem.po
+++ b/luci/luci-app-qmodem/po/zh-cn/qmodem.po
@@ -421,7 +421,7 @@ msgid "Mobile Country Code"
 msgstr "移动国家代码（MCC）"
 
 msgid "Mobile Network Code"
-msgstr "移动网络代码（MMC）"
+msgstr "移动网络代码（MNC）"
 
 msgid "Duplex Mode"
 msgstr "双工模式"

--- a/luci/luci-app-qmodem/po/zh_Hans/qmodem.po
+++ b/luci/luci-app-qmodem/po/zh_Hans/qmodem.po
@@ -420,7 +420,7 @@ msgid "Mobile Country Code"
 msgstr "移动国家代码（MCC）"
 
 msgid "Mobile Network Code"
-msgstr "移动网络代码（MMC）"
+msgstr "移动网络代码（MNC）"
 
 msgid "Duplex Mode"
 msgstr "双工模式"


### PR DESCRIPTION
先改翻译吧，显示的MNC写成了MMC

里面东西不敢改，5G状态下MCC键名是错的，也写成了MMC

https://zh.wikipedia.org/wiki/%E7%A7%BB%E5%8A%A8%E8%AE%BE%E5%A4%87%E7%BD%91%E7%BB%9C%E4%BB%A3%E7%A0%81

```
移动设备网络代码（英语：Mobile Network Code，MNC）是与[移动设备国家代码](https://zh.wikipedia.org/wiki/%E8%A1%8C%E5%8B%95%E8%A3%9D%E7%BD%AE%E5%9C%8B%E5%AE%B6%E4%BB%A3%E7%A2%BC)（Mobile Country Code，MCC）（也称为“MCC / MNC”）相结合，以用来表示唯一一个的移动设备的网络运营商。
```

![image](https://github.com/user-attachments/assets/2a3e290e-663f-48d7-814f-e12b034c45a1)
![image](https://github.com/user-attachments/assets/49a87235-6c93-4d16-8083-1df3eceae5f1)

