### PR TITLE
Update mhi_qti.h

### DIFF
--- a/driver/quectel_MHI/src/controllers/mhi_qti.h
+++ b/driver/quectel_MHI/src/controllers/mhi_qti.h
@@ -12,7 +12,9 @@
 #define MHI_SMMU_FORCE_COHERENT BIT(4)
 
 #define MHI_PCIE_VENDOR_ID (0x17cb)
-#define PCI_VENDOR_ID_FOXCONN (0x105b)
+#ifndef PCI_VENDOR_ID_FOXCONN
+#define PCI_VENDOR_ID_FOXCONN 0x105b
+#endif
 #define MHI_PCIE_DEBUG_ID (0xffff)
 
 /* runtime suspend timer */


### PR DESCRIPTION
add ifndef check for warning: "PCI_VENDOR_ID_FOXCONN" redefined.