### PR TITLE
fix fm/rw350 dial_err

### DIFF
--- a/application/qmodem/files/usr/share/qmodem/modem_dial.sh
+++ b/application/qmodem/files/usr/share/qmodem/modem_dial.sh
@@ -749,6 +749,7 @@ at_dial()
             case $platform in
                 "mediatek")
                     delay=3
+                    [ -z "$pdp_index" ] && pdp_index=3
                     [ "$apn" = "auto" ] && apn="cbnet"
                     at_command="AT+CGACT=1,$pdp_index"
                     cgdcont_command="AT+CGDCONT=$pdp_index,\"$pdp_type\",\"$apn\""


### PR DESCRIPTION
whe fm/rw 350 dial,it's only "AT+CGACT=1," the pdp_index is null,so i add the detect to resole it