### PR TITLE
fix qmodem_ttl 

### DIFF
--- a/luci/luci-app-qmodem-ttl/root/etc/init.d/qmodem_ttl
+++ b/luci/luci-app-qmodem-ttl/root/etc/init.d/qmodem_ttl
@@ -38,7 +38,6 @@ stop_service(){
     [ -f /etc/init.d/qca-nss-ecm ] && /etc/init.d/qca-nss-ecm start
     [ -e "/lib/modules/$kernel_version/shortcut-fe-cm.ko" ] && modprobe shortcut-fe-cm
     [ -e "/lib/modules/$kernel_version/fast-classifier.ko" ] && modprobe fast-classifier
-}
     /etc/init.d/firewall restart
 }
 


### PR DESCRIPTION
syntax error: unexpected "}"