### PR TITLE
add fibocom unisoc dial support

### DIFF
--- a/application/qmodem/files/usr/share/qmodem/modem_dial.sh
+++ b/application/qmodem/files/usr/share/qmodem/modem_dial.sh
@@ -764,6 +764,24 @@ at_dial()
                     at_command="AT+GTRNDIS=1,$pdp_index"
                     cgdcont_command="AT+CGDCONT=$pdp_index,\"$pdp_type\",\"$apn\""
                     ;;
+                "unisoc")
+                    at_command="AT+CGACT=1,$pdp_index"
+                    cgdcont_command="AT+CGDCONT=$pdp_index,\"$pdp_type\",\"$apn\""
+                    if [ -n "$auth" ]；then
+                        case $auth in
+                            "pap") 
+                                auth_num=1 ;;
+                            "chap") 
+                                auth_num=2 ;;
+                            "auto"|"both") 
+                                auth_num=3 ;;
+                            *) 
+                                auth_num=0 ;;
+                        esac
+                        if [ -n "$username" ] || [ -n "$password" ] && [ "$auth_num" != "0" ] ; then
+                            ppp_auth_command="AT+MGAUTH=$pdp_index,\"$auth_num\",\"$username\",\"$password\""
+                        fi
+                    fi
             esac
             ;;
         "huawei")
@@ -809,6 +827,7 @@ at_dial()
             ;;
     esac
 	m_debug "dialing: vendor:$manufacturer; platform:$platform; driver:$driver; apn:$apn; command:$at_command"
+    m_debug "dial_cmd: $at_command; cgdcont_cmd: $cgdcont_command; ppp_auth_cmd: $ppp_auth_command"
 	case $driver in
         "mtk_pcie")
             mbim_port=$(echo "$at_port" | sed 's/at/mbim/g')
@@ -820,6 +839,7 @@ at_dial()
 		 	;;
 		*)
   			at "${at_port}" "${cgdcont_command}"
+            [ -n "$ppp_auth_command" ] && at "${at_port}" "$ppp_auth_command"
         	at "$at_port" "$at_command"
 		 	;;
 	esac


### PR DESCRIPTION
- fix: add make clean step before compiling QModem
- sms_forwarder: fix some bug
- luci-app-qmodem: refactor: remove v4 connect check option and always enable ipv6 keep-alive
- quectel_QMI_WWAN: feat: add support for additional USB device IDs
- luci-app-qmodem: update modem_support.json
- Update support list
- fix(qmodem_init): For certain devices where the USB slot ID cannot be fixed, an additional check process has been added.
- modem_dial: fix: origin_device not found
- qmodem: add Fibocom L610-EU (unisoc) support
- Update support list
- Add APN options for Malaysia in dial_config.lua (#107)
- feat(at_dial): add Unisoc support for PDP activation and PPP authentication
