### PR TITLE
fix(sms_forwarder): add all sms_forward_*.sh to package

### DIFF
--- a/application/sms_forwarder/Makefile
+++ b/application/sms_forwarder/Makefile
@@ -39,11 +39,7 @@ endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sms_forwarder $(1)/usr/bin/
-	$(INSTALL_BIN) ./files/usr/bin/sms_forward_serverchan.sh $(1)/usr/bin/
-	$(INSTALL_BIN) ./files/usr/bin/sms_forward_webhook.sh $(1)/usr/bin/
-	$(INSTALL_BIN) ./files/usr/bin/sms_forward_tgbot.sh $(1)/usr/bin/
-	$(INSTALL_BIN) ./files/usr/bin/sms_forward_pushdeer.sh $(1)/usr/bin/
-	$(INSTALL_BIN) ./files/usr/bin/sms_forward_custom_example.sh $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/usr/bin/sms_forward_*.sh $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/sms_forwarder $(1)/etc/init.d/
 	$(INSTALL_DIR) $(1)/etc/config


### PR DESCRIPTION
sms_forwarder 的 Makefile 中未添加 sms_forward_feishu.sh，安装后在 /usr/bin 中无该脚本，导致飞书转发不可用。参考 sms_forwarder_next 的 Makefile 将相关脚本一键打包。
- 修改前：如图，缺少 sms_forward_feishu.sh
<img width="843" height="589" alt="修改前" src="https://github.com/user-attachments/assets/ac25f058-2b6e-41ee-9291-2e6ec43b0342" />

- 修改后：如图，所有 sms_forward_*.sh 均被添加
<img width="843" height="589" alt="修改后" src="https://github.com/user-attachments/assets/24abeb70-ca74-4a68-a0f6-ab4204f664af" />
