### PR TITLE
feat(ttl): 添加中文翻译并修复配置

### DIFF
--- a/luci/luci-app-qmodem-ttl/Makefile
+++ b/luci/luci-app-qmodem-ttl/Makefile
@@ -14,10 +14,11 @@ PKG_LICENSE:=GPLv3
 PKG_LINCESE_FILES:=LICENSE
 PKG_MAINTAINER:=Tom <fjrcn@outlook.com>
 LUCI_DEPENDS:=+luci-app-qmodem
+PKG_CONFLICTS:=luci-app-qmodem-ttlfw4
 		
 
 define Package/luci-app-qmodem-ttl/conffiles
-/etc/config/modem_ttl
+/etc/config/qmodem_ttl
 endef
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/luci/luci-app-qmodem-ttl/po/templates/qmodem-ttl.pot
+++ b/luci/luci-app-qmodem-ttl/po/templates/qmodem-ttl.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: luasrc/controller/qmodem_ttl.lua:6
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:2
+msgid "TTL Config"
+msgstr ""
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:3
+msgid "Global Config"
+msgstr ""
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:5
+msgid "Enable"
+msgstr ""
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:8
+msgid "TTL"
+msgstr ""

--- a/luci/luci-app-qmodem-ttl/po/zh_Hans/qmodem-ttl.po
+++ b/luci/luci-app-qmodem-ttl/po/zh_Hans/qmodem-ttl.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: luasrc/controller/qmodem_ttl.lua:6
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:2
+msgid "TTL Config"
+msgstr "TTL 配置"
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:3
+msgid "Global Config"
+msgstr "全局配置"
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:5
+msgid "Enable"
+msgstr "启用"
+
+#: luasrc/model/cbi/qmodem/modem_ttl.lua:8
+msgid "TTL"
+msgstr "TTL 值"

--- a/luci/luci-app-qmodem-ttlfw4/Makefile
+++ b/luci/luci-app-qmodem-ttlfw4/Makefile
@@ -9,6 +9,7 @@ include ../../version.mk
 PKG_NAME:=luci-app-qmodem-ttlfw4
 LUCI_TITLE:=LuCI App for QModem TTL Configuration (JS LuCI / fw4 Only)
 LUCI_DEPENDS:=+luci-base
+PKG_CONFLICTS:=luci-app-qmodem-ttl
 LUCI_PKGARCH:=all
 PKG_VERSION:=$(QMODEM_VERSION)
 PKG_RELEASE:=1

--- a/luci/luci-app-qmodem-ttlfw4/po/templates/qmodem-ttlfw4.pot
+++ b/luci/luci-app-qmodem-ttlfw4/po/templates/qmodem-ttlfw4.pot
@@ -1,0 +1,41 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "TTL Configuration"
+msgstr ""
+
+msgid "Configure TTL/Hop Limit settings to modify outgoing packet TTL values. This can help bypass carrier restrictions on tethering."
+msgstr ""
+
+msgid "Global TTL Settings"
+msgstr ""
+
+msgid "Enable TTL Modification"
+msgstr ""
+
+msgid "Enable or disable TTL/Hop Limit modification for outgoing packets."
+msgstr ""
+
+msgid "TTL Value"
+msgstr ""
+
+msgid "Set the TTL (Time To Live) value for IPv4 packets and Hop Limit for IPv6 packets. Common values: 64 (Linux default), 128 (Windows default)."
+msgstr ""
+
+msgid "Important Notes"
+msgstr ""
+
+msgid "Warning:"
+msgstr ""
+
+msgid "Enabling TTL modification will disable hardware flow offloading for proper packet modification."
+msgstr ""
+
+msgid "This may affect network performance on some devices."
+msgstr ""
+
+msgid "NSS ECM, SFE, and other acceleration modules will be disabled when TTL modification is active."
+msgstr ""
+
+msgid "Settings will take effect after saving and applying changes."
+msgstr ""

--- a/luci/luci-app-qmodem-ttlfw4/po/zh_Hans/qmodem-ttlfw4.po
+++ b/luci/luci-app-qmodem-ttlfw4/po/zh_Hans/qmodem-ttlfw4.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "TTL Configuration"
+msgstr "TTL 配置"
+
+msgid "Configure TTL/Hop Limit settings to modify outgoing packet TTL values. This can help bypass carrier restrictions on tethering."
+msgstr "配置 TTL/跳数限制设置以修改出站数据包的 TTL 值。这可以帮助绕过运营商对网络共享的限制。"
+
+msgid "Global TTL Settings"
+msgstr "全局 TTL 设置"
+
+msgid "Enable TTL Modification"
+msgstr "启用 TTL 修改"
+
+msgid "Enable or disable TTL/Hop Limit modification for outgoing packets."
+msgstr "启用或禁用出站数据包的 TTL/跳数限制修改。"
+
+msgid "TTL Value"
+msgstr "TTL 值"
+
+msgid "Set the TTL (Time To Live) value for IPv4 packets and Hop Limit for IPv6 packets. Common values: 64 (Linux default), 128 (Windows default)."
+msgstr "设置 IPv4 数据包的 TTL（生存时间）值和 IPv6 数据包的跳数限制。常用值：64（Linux 默认）、128（Windows 默认）。"
+
+msgid "Important Notes"
+msgstr "重要说明"
+
+msgid "Warning:"
+msgstr "警告："
+
+msgid "Enabling TTL modification will disable hardware flow offloading for proper packet modification."
+msgstr "启用 TTL 修改将禁用硬件流量卸载以确保正确修改数据包。"
+
+msgid "This may affect network performance on some devices."
+msgstr "这可能会影响某些设备的网络性能。"
+
+msgid "NSS ECM, SFE, and other acceleration modules will be disabled when TTL modification is active."
+msgstr "当 TTL 修改激活时，NSS ECM、SFE 和其他加速模块将被禁用。"
+
+msgid "Settings will take effect after saving and applying changes."
+msgstr "设置将在保存并应用更改后生效。"


### PR DESCRIPTION
## 更改内容

### luci-app-qmodem-ttl
- 添加 `po/zh_Hans/qmodem-ttl.po` 中文翻译文件
- 添加 `po/templates/qmodem-ttl.pot` 翻译模板
- 修复 Makefile 中 conffiles 路径错误（`modem_ttl` → `qmodem_ttl`）
- 添加 `PKG_CONFLICTS:=luci-app-qmodem-ttlfw4` 避免与 fw4 版本冲突

### luci-app-qmodem-ttlfw4
- 添加 `po/zh_Hans/qmodem-ttlfw4.po` 中文翻译文件
- 添加 `po/templates/qmodem-ttlfw4.pot` 翻译模板
- 添加 `PKG_CONFLICTS:=luci-app-qmodem-ttl` 避免与 Lua 版本冲突

## 翻译内容

### luci-app-qmodem-ttl (Lua 版本)
| 原文 | 中文 |
|------|------|
| TTL Config | TTL 配置 |
| Global Config | 全局配置 |
| Enable | 启用 |
| TTL | TTL 值 |

### luci-app-qmodem-ttlfw4 (JS 版本)
| 原文 | 中文 |
|------|------|
| TTL Configuration | TTL 配置 |
| Global TTL Settings | 全局 TTL 设置 |
| Enable TTL Modification | 启用 TTL 修改 |
| TTL Value | TTL 值 |
| Important Notes | 重要说明 |
| Warning: | 警告： |
| 以及所有警告说明文本 | 已完整翻译 |