### PR TITLE
使用pid文件管理quectel-CM-M和quectel-CM进程，不依赖quectel-CM自身的kill功能

### DIFF
--- a/application/qmodem/files/usr/share/qmodem/modem_dial.sh
+++ b/application/qmodem/files/usr/share/qmodem/modem_dial.sh
@@ -593,9 +593,11 @@ dial(){
 
 wwan_hang()
 {
-    m_debug "wwan_hang"
-    #killall quectel-CM
-    #killall quectel-CM-M
+    pid=$(cat "${MODEM_RUNDIR}/${modem_config}_dir/$modem_config.pid")
+    m_debug "wwan_hang, pid = $pid"
+    if [ -n $pid ]; then
+        kill $pid
+    fi
 }
 
 ecm_hang()
@@ -752,7 +754,10 @@ qmi_dial()
     cmd_line="$cmd_line -f $log_file"
     while true; do
         m_debug "dialing: $cmd_line"
-        $cmd_line
+        $cmd_line &
+        echo "$!" > "${MODEM_RUNDIR}/${modem_config}_dir/$modem_config.pid"
+        m_debug "pid: $!"
+        wait
         m_debug "quectel-CM exited, retrying dial"
     done
 }


### PR DESCRIPTION
使用pid文件管理quectel-CM-M和quectel-CM进程，不依赖quectel-CM自身的kill功能，在1.6.8版本中依赖quectel-CM自身的kill功能会杀不掉旧进程导致resource busy错误，现在拉起quectel-CM和quectel-CM-M进程时会创建/var/run/qmodem/$modem_config_dir/$modem_config.pid文件并记录pid，hang时同样kill掉该pid