### PR TITLE
fix: issue#201 

### DIFF
--- a/application/qmodem/files/etc/init.d/qmodem_init
+++ b/application/qmodem/files/etc/init.d/qmodem_init
@@ -3,7 +3,7 @@ START=80
 STOP=30
 USE_PROCD=1
 
-. /lib/functions.sh
+. $IPKG_INSTROOT/lib/functions.sh
 
 start_service() {
 	config_load qmodem

--- a/application/qmodem/files/etc/init.d/qmodem_usage_stats
+++ b/application/qmodem/files/etc/init.d/qmodem_usage_stats
@@ -4,7 +4,7 @@ START=96
 STOP=10
 USE_PROCD=1
 
-. /lib/functions.sh
+. $IPKG_INSTROOT/lib/functions.sh
 
 MIN_INTERVAL=60
 DEFAULT_INTERVAL=300

--- a/application/qmodem_monitor/files/etc/init.d/qmodem_monitor
+++ b/application/qmodem_monitor/files/etc/init.d/qmodem_monitor
@@ -3,7 +3,7 @@ START=99
 STOP=13
 USE_PROCD=1
 service="$(basename ${basescript:-$initscript})"
-. /lib/functions.sh
+. $IPKG_INSTROOT/lib/functions.sh
 service_triggers()
 {
 	procd_add_reload_trigger "qmodem"

--- a/luci/luci-app-qmodem-ttl/root/etc/init.d/qmodem_ttl
+++ b/luci/luci-app-qmodem-ttl/root/etc/init.d/qmodem_ttl
@@ -3,8 +3,8 @@ START=95
 STOP=13
 USE_PROCD=1
 
-. /usr/share/libubox/jshn.sh
-. /lib/functions.sh
+. $IPKG_INSTROOT/usr/share/libubox/jshn.sh
+. $IPKG_INSTROOT/lib/functions.sh
 start_service()
 {
     config_load 'qmodem_ttl'

--- a/luci/luci-app-qmodem-ttlfw4/root/etc/init.d/qmodem_ttl
+++ b/luci/luci-app-qmodem-ttlfw4/root/etc/init.d/qmodem_ttl
@@ -3,8 +3,8 @@ START=95
 STOP=13
 USE_PROCD=1
 
-. /usr/share/libubox/jshn.sh
-. /lib/functions.sh
+. $IPKG_INSTROOT/usr/share/libubox/jshn.sh
+. $IPKG_INSTROOT/lib/functions.sh
 
 nftfile="/etc/nftables.d/99-reset-ttl-from-br-lan.nft"
 start_service()


### PR DESCRIPTION
修复QModem部分软件包在OpenWrt固件构建过程中出现的 `/lib/functions.sh: No such file or directory` 等报错（#201 ）

- 修改前的构建过程：
```
Enabling pcie_mhi
Enabling podman
./etc/init.d/qmodem_init: line 6: /lib/functions.sh: No such file or directory
Enabling qmodem_init
./etc/init.d/qmodem_monitor: line 6: /lib/functions.sh: No such file or directory
Enabling qmodem_monitor
Enabling qmodem_network
Enabling qmodem_reboot
./etc/init.d/qmodem_ttl: line 6: /usr/share/libubox/jshn.sh: No such file or directory
./etc/init.d/qmodem_ttl: line 7: /lib/functions.sh: No such file or directory
Enabling qmodem_ttl
```

- 修改后的构建过程：
```
Enabling pcie_mhi
Enabling podman
Enabling qmodem_init
Enabling qmodem_monitor
Enabling qmodem_network
Enabling qmodem_reboot
Enabling qmodem_ttl
Enabling qmodem_usage_stats
```

- 修改并运行后的效果：
```
root@immortalwrt:~# ls -l /var/run/qmodem/
drwxr-xr-x    2 root     root            80 Apr 21 20:49 0000_01_00_0_dir
```
可见修改后相关软件包的init脚本成功启用，且init脚本 `/etc/init.d/qmodem_init` 在修改后仍能够正常运行