### PR TITLE
Add Sierra Wireless EM9291 modem support to modem_support.json

### DIFF
--- a/application/qmodem/files/usr/share/qmodem/modem_support.json
+++ b/application/qmodem/files/usr/share/qmodem/modem_support.json
@@ -1085,6 +1085,17 @@
                     "rmnet"
                 ]
             },
+            "em9291": {
+                "manufacturer_id": "1199",
+                "manufacturer": "sierra",
+                "platform": "qualcomm",
+                "data_interface": "usb",
+                "pdp_index": "1",
+                "modes": [
+                    "mbim",
+                    "rmnet"
+                ]
+            },
             "mc7354": {
                 "manufacturer_id": "1199",
                 "manufacturer": "sierra",
@@ -1727,6 +1738,16 @@
                 ]
             },
             "em9190": {
+                "manufacturer": "sierra",
+                "platform": "qualcomm",
+                "data_interface": "pcie",
+                "pdp_index": "1",
+                "modes": [
+                    "mbim",
+                    "rmnet"
+                ]
+            },
+            "em9291": {
                 "manufacturer": "sierra",
                 "platform": "qualcomm",
                 "data_interface": "pcie",


### PR DESCRIPTION
Added support for the Sierra Wireless EM9291 5G module.