### PR TITLE
feat: 增加加密 fixture 反馈包支持

### DIFF
--- a/.github/workflows/vendor-fixtures.yml
+++ b/.github/workflows/vendor-fixtures.yml
@@ -20,7 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install fixture tools
-        run: sudo apt-get update && sudo apt-get install -y jq xxd
+        run: sudo apt-get update && sudo apt-get install -y gcc jq libsodium-dev xxd
+      - name: Build and test qmodem-seal
+        run: |
+          gcc -std=c11 -O2 -Wall -Wextra -Werror \
+            -o /tmp/qmodem-seal application/qmodem-seal/src/qmodem-seal.c -lsodium
+          application/qmodem-seal/tests/test_qmodem_seal.sh /tmp/qmodem-seal
       - name: Check shell syntax
         run: |
           find application/qmodem/files/usr/share/qmodem/cmds \
@@ -31,6 +36,7 @@ jobs:
           sh -n application/qmodem/files/usr/share/qmodem/modem_util.sh
           sh -n application/qmodem/files/usr/sbin/qmodem_collect
           sh -n application/qmodem/tests/test_core_cmds.sh
+          bash -n application/qmodem/tests/test_collect_encryption.sh
           sh -n application/qmodem/tests/test_vendor_cmds_boundary.sh
           bash -n application/qmodem/tests/test_fixture_collection_bytes.sh
           bash -n application/qmodem/tests/test_vendor_fixtures.sh
@@ -39,5 +45,7 @@ jobs:
           application/qmodem/tests/test_vendor_cmds_boundary.sh
           application/qmodem/tests/test_core_cmds.sh
           application/qmodem/tests/test_fixture_collection_bytes.sh
+          QMODEM_TEST_SEAL_BIN=/tmp/qmodem-seal \
+            application/qmodem/tests/test_collect_encryption.sh
       - name: Replay vendor fixtures
         run: application/qmodem/tests/test_vendor_fixtures.sh

--- a/application/qmodem-seal/Makefile
+++ b/application/qmodem-seal/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+include ../../version.mk
+
+PKG_NAME:=qmodem-seal
+PKG_VERSION:=$(QMODEM_VERSION)
+PKG_RELEASE:=$(QMODEM_RELEASE)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/qmodem-seal
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=QModem encrypted feedback tool
+  DEPENDS:=+libsodium
+endef
+
+define Package/qmodem-seal/description
+  Encrypts QModem feedback for a maintainer recipient and derives a
+  reproducible recipient identity from a user-supplied recovery token.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Compile
+	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) \
+		-Wall -Wextra -Werror -o $(PKG_BUILD_DIR)/qmodem-seal \
+		$(PKG_BUILD_DIR)/qmodem-seal.c $(TARGET_LDFLAGS) -lsodium
+endef
+
+define Package/qmodem-seal/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qmodem-seal $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,qmodem-seal))

--- a/application/qmodem-seal/README.md
+++ b/application/qmodem-seal/README.md
@@ -1,0 +1,69 @@
+# qmodem-seal
+
+`qmodem-seal` encrypts collected QModem fixture archives before contributors
+upload them to a public issue. It is an optional package selected by default by
+QModem.
+
+## Identity
+
+The maintainer chooses a case-sensitive 16-64 character ASCII token using only
+`A-Z`, `a-z`, `0-9`, `.`, `_`, and `-`. The token is read from the terminal
+without echo and is never passed as a command-line argument.
+
+```sh
+qmodem-seal identity derive
+```
+
+The command asks for the token twice and prints a reproducible public recipient
+and recipient ID. The same token always produces the same identity. The token
+must never be published; releases contain only the public recipient.
+
+Identity derivation uses Argon2id 1.3 with libsodium's moderate limits, a fixed
+`QModemSealTokV1!` domain salt, and `crypto_box_seed_keypair`. Changing these
+parameters would create a new token format version.
+
+## Feedback format
+
+An encrypted feedback file is an uncompressed outer tar:
+
+```text
+qmodem_feedback_<timestamp>.tar
+  manifest.json
+  payload.enc
+```
+
+- `payload.enc` is a framed libsodium secretstream using
+  XChaCha20-Poly1305 and a fresh random 256-bit review key.
+- `manifest.json` contains non-secret routing metadata and the review key
+  wrapped for the release recipient with a libsodium sealed box. Possession of
+  the manifest does not reveal the review key without the identity token.
+
+The contributor receives the per-package review password/key after packing and
+can decrypt the feedback locally. It is a generated key rather than a
+human-chosen password, so it can safely carry the full encryption strength:
+
+```sh
+qmodem-seal decrypt --review-key \
+  --input qmodem_feedback_<timestamp>.tar \
+  --output qmodem_review.tar.gz
+```
+
+The maintainer omits `--review-key` and enters the identity token instead:
+
+```sh
+qmodem-seal decrypt \
+  --input qmodem_feedback_<timestamp>.tar \
+  --output qmodem_testcases.tar.gz
+```
+
+Another project maintainer can extract and send only `manifest.json` to the
+identity owner. The owner does not need to download `payload.enc`; this command
+recovers the package-specific review key for the other maintainer:
+
+```sh
+qmodem-seal review-key --manifest manifest.json
+```
+
+Plaintext is not released until every encrypted frame and the final stream tag
+have been authenticated. Different encryptions of the same input produce
+different ciphertexts.

--- a/application/qmodem-seal/src/qmodem-seal.c
+++ b/application/qmodem-seal/src/qmodem-seal.c
@@ -1,0 +1,553 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <sodium.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define TOKEN_MIN 16
+#define TOKEN_MAX 64
+#define IO_CHUNK 65536
+#define PAYLOAD_MAGIC "QMSPAY1\n"
+#define KEY_MAGIC "QMSKEY1\n"
+#define RECIPIENT_PREFIX "qms1:"
+#define REVIEW_PREFIX "qmr1:"
+
+static const unsigned char token_salt[crypto_pwhash_SALTBYTES] = {
+    'Q','M','o','d','e','m','S','e','a','l','T','o','k','V','1','!'
+};
+
+static void usage(void)
+{
+    fprintf(stderr,
+        "usage:\n"
+        "  qmodem-seal identity derive [--token-stdin]\n"
+        "  qmodem-seal seal --recipient PUB --input FILE --payload FILE --key FILE\n"
+        "  qmodem-seal review-key --manifest FILE [--token-stdin]\n"
+        "  qmodem-seal decrypt --input FEEDBACK.tar --output FILE [--review-key] [--token-stdin]\n");
+    exit(2);
+}
+
+static void die(const char *message)
+{
+    fprintf(stderr, "qmodem-seal: %s\n", message);
+    exit(1);
+}
+
+static int write_all(FILE *out, const void *data, size_t size)
+{
+    return fwrite(data, 1, size, out) == size ? 0 : -1;
+}
+
+static int read_secret(const char *prompt, char *buffer, size_t size, int stdin_mode)
+{
+    FILE *in = stdin;
+    struct termios old_term, new_term;
+    int tty_fd = -1;
+    int hide = 0;
+
+    if (!stdin_mode) {
+        tty_fd = open("/dev/tty", O_RDWR);
+        if (tty_fd < 0)
+            return -1;
+        in = fdopen(tty_fd, "r");
+        if (!in) {
+            close(tty_fd);
+            return -1;
+        }
+        fprintf(stderr, "%s", prompt);
+        fflush(stderr);
+        if (tcgetattr(tty_fd, &old_term) == 0) {
+            new_term = old_term;
+            new_term.c_lflag &= (tcflag_t)~ECHO;
+            if (tcsetattr(tty_fd, TCSAFLUSH, &new_term) == 0)
+                hide = 1;
+        }
+    }
+
+    if (!fgets(buffer, (int)size, in)) {
+        if (hide)
+            tcsetattr(tty_fd, TCSAFLUSH, &old_term);
+        if (!stdin_mode)
+            fclose(in);
+        return -1;
+    }
+    if (hide) {
+        tcsetattr(tty_fd, TCSAFLUSH, &old_term);
+        fputc('\n', stderr);
+    }
+    if (!stdin_mode)
+        fclose(in);
+
+    buffer[strcspn(buffer, "\r\n")] = '\0';
+    return 0;
+}
+
+static int validate_token(const char *token)
+{
+    size_t i, len = strlen(token);
+    if (len < TOKEN_MIN || len > TOKEN_MAX)
+        return -1;
+    for (i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)token[i];
+        if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+              (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-'))
+            return -1;
+    }
+    return 0;
+}
+
+static int derive_keypair(const char *token, unsigned char pk[crypto_box_PUBLICKEYBYTES],
+                          unsigned char sk[crypto_box_SECRETKEYBYTES])
+{
+    unsigned char seed[crypto_box_SEEDBYTES];
+    int rc;
+
+    if (validate_token(token) != 0)
+        return -1;
+    rc = crypto_pwhash(seed, sizeof(seed), token, strlen(token), token_salt,
+                       crypto_pwhash_OPSLIMIT_MODERATE,
+                       crypto_pwhash_MEMLIMIT_MODERATE,
+                       crypto_pwhash_ALG_ARGON2ID13);
+    if (rc != 0)
+        return -1;
+    crypto_box_seed_keypair(pk, sk, seed);
+    sodium_memzero(seed, sizeof(seed));
+    return 0;
+}
+
+static void encode_value(const char *prefix, const unsigned char *value, size_t value_len,
+                         char *output, size_t output_len)
+{
+    size_t prefix_len = strlen(prefix);
+    if (output_len <= prefix_len)
+        die("internal encoding buffer is too small");
+    memcpy(output, prefix, prefix_len);
+    sodium_bin2base64(output + prefix_len, output_len - prefix_len, value, value_len,
+                      sodium_base64_VARIANT_URLSAFE_NO_PADDING);
+}
+
+static int decode_value(const char *encoded, const char *prefix, unsigned char *output,
+                        size_t expected_len)
+{
+    size_t actual_len = 0;
+    size_t prefix_len = strlen(prefix);
+    if (strncmp(encoded, prefix, prefix_len) != 0)
+        return -1;
+    if (sodium_base642bin(output, expected_len, encoded + prefix_len,
+                          strlen(encoded + prefix_len), NULL, &actual_len, NULL,
+                          sodium_base64_VARIANT_URLSAFE_NO_PADDING) != 0)
+        return -1;
+    return actual_len == expected_len ? 0 : -1;
+}
+
+static void print_identity(const unsigned char pk[crypto_box_PUBLICKEYBYTES])
+{
+    unsigned char id[8];
+    char recipient[64];
+    size_t i;
+
+    encode_value(RECIPIENT_PREFIX, pk, crypto_box_PUBLICKEYBYTES,
+                 recipient, sizeof(recipient));
+    crypto_generichash(id, sizeof(id), pk, crypto_box_PUBLICKEYBYTES, NULL, 0);
+    printf("recipient=%s\nrecipient_id=qms1-", recipient);
+    for (i = 0; i < sizeof(id); i++)
+        printf("%02x", id[i]);
+    putchar('\n');
+}
+
+static void command_identity(int argc, char **argv)
+{
+    char token[TOKEN_MAX + 2], confirm[TOKEN_MAX + 2];
+    unsigned char pk[crypto_box_PUBLICKEYBYTES], sk[crypto_box_SECRETKEYBYTES];
+    int stdin_mode = argc == 4 && strcmp(argv[3], "--token-stdin") == 0;
+
+    if (argc < 3 || argc > 4 || strcmp(argv[2], "derive") != 0 ||
+        (argc == 4 && !stdin_mode))
+        usage();
+    if (read_secret("Token: ", token, sizeof(token), stdin_mode) != 0 ||
+        read_secret("Confirm token: ", confirm, sizeof(confirm), stdin_mode) != 0)
+        die("failed to read token");
+    if (strcmp(token, confirm) != 0)
+        die("tokens do not match");
+    if (validate_token(token) != 0)
+        die("token must be 16-64 characters using A-Z, a-z, 0-9, '.', '_' or '-'");
+    if (derive_keypair(token, pk, sk) != 0)
+        die("failed to derive identity");
+    print_identity(pk);
+    sodium_memzero(sk, sizeof(sk));
+    sodium_memzero(token, sizeof(token));
+    sodium_memzero(confirm, sizeof(confirm));
+}
+
+static void write_u32(FILE *out, uint32_t value)
+{
+    unsigned char b[4] = {
+        (unsigned char)(value >> 24), (unsigned char)(value >> 16),
+        (unsigned char)(value >> 8), (unsigned char)value
+    };
+    if (write_all(out, b, sizeof(b)) != 0)
+        die("failed to write encrypted payload");
+}
+
+static int read_u32(FILE *in, uint32_t *value)
+{
+    unsigned char b[4];
+    size_t n = fread(b, 1, sizeof(b), in);
+    if (n == 0 && feof(in))
+        return 0;
+    if (n != sizeof(b))
+        return -1;
+    *value = ((uint32_t)b[0] << 24) | ((uint32_t)b[1] << 16) |
+             ((uint32_t)b[2] << 8) | b[3];
+    return 1;
+}
+
+static void encrypt_payload(const char *input_path, const char *output_path,
+                            const unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES])
+{
+    FILE *in = fopen(input_path, "rb");
+    FILE *out = NULL;
+    crypto_secretstream_xchacha20poly1305_state state;
+    unsigned char header[crypto_secretstream_xchacha20poly1305_HEADERBYTES];
+    unsigned char plain[IO_CHUNK];
+    unsigned char cipher[IO_CHUNK + crypto_secretstream_xchacha20poly1305_ABYTES];
+    unsigned long long cipher_len;
+
+    if (!in)
+        die("failed to open input archive");
+    out = fopen(output_path, "wb");
+    if (!out) {
+        fclose(in);
+        die("failed to create encrypted payload");
+    }
+    crypto_secretstream_xchacha20poly1305_init_push(&state, header, key);
+    if (write_all(out, PAYLOAD_MAGIC, 8) != 0 ||
+        write_all(out, header, sizeof(header)) != 0)
+        die("failed to write encrypted payload header");
+
+    for (;;) {
+        size_t n = fread(plain, 1, sizeof(plain), in);
+        unsigned char tag;
+        if (ferror(in))
+            die("failed to read input archive");
+        tag = (n < sizeof(plain) && feof(in)) ?
+            crypto_secretstream_xchacha20poly1305_TAG_FINAL : 0;
+        crypto_secretstream_xchacha20poly1305_push(&state, cipher, &cipher_len,
+                                                    plain, n, NULL, 0, tag);
+        write_u32(out, (uint32_t)cipher_len);
+        if (write_all(out, cipher, (size_t)cipher_len) != 0)
+            die("failed to write encrypted payload");
+        if (tag == crypto_secretstream_xchacha20poly1305_TAG_FINAL)
+            break;
+    }
+    if (fclose(in) != 0 || fclose(out) != 0)
+        die("failed to finalize encrypted payload");
+}
+
+static void write_wrapped_key(const char *path, const unsigned char *key,
+                              const unsigned char recipient[crypto_box_PUBLICKEYBYTES])
+{
+    unsigned char sealed[crypto_box_SEALBYTES + crypto_secretstream_xchacha20poly1305_KEYBYTES];
+    FILE *out;
+    crypto_box_seal(sealed, key, crypto_secretstream_xchacha20poly1305_KEYBYTES, recipient);
+    out = fopen(path, "wb");
+    if (!out)
+        die("failed to create wrapped key");
+    if (write_all(out, KEY_MAGIC, 8) != 0 || write_all(out, sealed, sizeof(sealed)) != 0 ||
+        fclose(out) != 0)
+        die("failed to write wrapped key");
+}
+
+static const char *option_value(int argc, char **argv, const char *name)
+{
+    int i;
+    for (i = 2; i + 1 < argc; i++)
+        if (strcmp(argv[i], name) == 0)
+            return argv[i + 1];
+    return NULL;
+}
+
+static int has_option(int argc, char **argv, const char *name)
+{
+    int i;
+    for (i = 2; i < argc; i++)
+        if (strcmp(argv[i], name) == 0)
+            return 1;
+    return 0;
+}
+
+static void command_seal(int argc, char **argv)
+{
+    const char *recipient_text = option_value(argc, argv, "--recipient");
+    const char *input = option_value(argc, argv, "--input");
+    const char *payload = option_value(argc, argv, "--payload");
+    const char *key_path = option_value(argc, argv, "--key");
+    unsigned char recipient[crypto_box_PUBLICKEYBYTES];
+    unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES];
+    char review[64];
+
+    if (!recipient_text || !input || !payload || !key_path)
+        usage();
+    if (decode_value(recipient_text, RECIPIENT_PREFIX, recipient, sizeof(recipient)) != 0)
+        die("invalid recipient");
+    randombytes_buf(key, sizeof(key));
+    encrypt_payload(input, payload, key);
+    write_wrapped_key(key_path, key, recipient);
+    encode_value(REVIEW_PREFIX, key, sizeof(key), review, sizeof(review));
+    printf("review_key=%s\n", review);
+    sodium_memzero(key, sizeof(key));
+}
+
+struct tar_members {
+    FILE *payload;
+    FILE *manifest;
+};
+
+static unsigned long long tar_size(const unsigned char *field, size_t len)
+{
+    unsigned long long value = 0;
+    size_t i;
+    for (i = 0; i < len && (field[i] == ' ' || field[i] == '\0'); i++) {}
+    for (; i < len && field[i] >= '0' && field[i] <= '7'; i++)
+        value = value * 8 + (unsigned long long)(field[i] - '0');
+    return value;
+}
+
+static int copy_member(FILE *archive, FILE *out, unsigned long long size)
+{
+    unsigned char buffer[IO_CHUNK];
+    while (size > 0) {
+        size_t want = size > sizeof(buffer) ? sizeof(buffer) : (size_t)size;
+        if (fread(buffer, 1, want, archive) != want || write_all(out, buffer, want) != 0)
+            return -1;
+        size -= want;
+    }
+    return 0;
+}
+
+static struct tar_members read_feedback_tar(const char *path)
+{
+    struct tar_members members = { tmpfile(), tmpfile() };
+    FILE *archive = fopen(path, "rb");
+    unsigned char header[512], discard[512];
+
+    if (!archive || !members.payload || !members.manifest)
+        die("failed to open feedback archive");
+    for (;;) {
+        char name[101];
+        unsigned long long size, padded, consumed = 0;
+        int all_zero = 1;
+        size_t i;
+        if (fread(header, 1, sizeof(header), archive) != sizeof(header))
+            die("invalid feedback tar header");
+        for (i = 0; i < sizeof(header); i++)
+            if (header[i] != 0) { all_zero = 0; break; }
+        if (all_zero)
+            break;
+        memcpy(name, header, 100);
+        name[100] = '\0';
+        size = tar_size(header + 124, 12);
+        padded = (size + 511) & ~511ULL;
+        if (strcmp(name, "payload.enc") == 0 || strcmp(name, "./payload.enc") == 0) {
+            if (copy_member(archive, members.payload, size) != 0)
+                die("failed to read payload member");
+            consumed = size;
+        } else if (strcmp(name, "manifest.json") == 0 || strcmp(name, "./manifest.json") == 0) {
+            if (copy_member(archive, members.manifest, size) != 0)
+                die("failed to read manifest member");
+            consumed = size;
+        }
+        while (consumed < padded) {
+            size_t want = padded - consumed > sizeof(discard) ? sizeof(discard) :
+                          (size_t)(padded - consumed);
+            if (fread(discard, 1, want, archive) != want)
+                die("truncated feedback tar member");
+            consumed += want;
+        }
+    }
+    fclose(archive);
+    if (ftell(members.payload) == 0 || ftell(members.manifest) == 0)
+        die("feedback tar is missing payload.enc or manifest.json");
+    rewind(members.payload);
+    rewind(members.manifest);
+    return members;
+}
+
+static void read_manifest_wrapped_key(FILE *manifest, unsigned char *wrapped,
+                                      size_t wrapped_len)
+{
+    char json[8192];
+    char *field, *value, *end;
+    size_t json_len, decoded_len = 0;
+
+    rewind(manifest);
+    json_len = fread(json, 1, sizeof(json) - 1, manifest);
+    if (ferror(manifest) || (!feof(manifest) && json_len == sizeof(json) - 1))
+        die("manifest is too large or unreadable");
+    json[json_len] = '\0';
+    field = strstr(json, "\"wrapped_key_hex\"");
+    if (!field || !(value = strchr(field, ':')))
+        die("manifest is missing wrapped_key_hex");
+    value++;
+    while (*value == ' ' || *value == '\t' || *value == '\r' || *value == '\n')
+        value++;
+    if (*value++ != '\"' || !(end = strchr(value, '\"')))
+        die("manifest has invalid wrapped_key_hex");
+    if (sodium_hex2bin(wrapped, wrapped_len, value, (size_t)(end - value),
+                       NULL, &decoded_len, NULL) != 0 || decoded_len != wrapped_len)
+        die("manifest has invalid wrapped_key_hex");
+}
+
+static void unwrap_manifest_key(FILE *manifest,
+                                const unsigned char pk[crypto_box_PUBLICKEYBYTES],
+                                const unsigned char sk[crypto_box_SECRETKEYBYTES],
+                                unsigned char *key)
+{
+    unsigned char wrapped[8 + crypto_box_SEALBYTES +
+                          crypto_secretstream_xchacha20poly1305_KEYBYTES];
+    read_manifest_wrapped_key(manifest, wrapped, sizeof(wrapped));
+    if (memcmp(wrapped, KEY_MAGIC, 8) != 0 ||
+        crypto_box_seal_open(key, wrapped + 8, sizeof(wrapped) - 8, pk, sk) != 0)
+        die("token does not match feedback recipient");
+}
+
+static void command_review_key(int argc, char **argv)
+{
+    const char *manifest_path = option_value(argc, argv, "--manifest");
+    int stdin_mode = has_option(argc, argv, "--token-stdin");
+    unsigned char pk[crypto_box_PUBLICKEYBYTES], sk[crypto_box_SECRETKEYBYTES];
+    unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES];
+    char token[TOKEN_MAX + 2], review[64];
+    FILE *manifest;
+
+    if (!manifest_path)
+        usage();
+    manifest = fopen(manifest_path, "rb");
+    if (!manifest)
+        die("failed to open manifest");
+    if (read_secret("Token: ", token, sizeof(token), stdin_mode) != 0 ||
+        derive_keypair(token, pk, sk) != 0)
+        die("invalid token or identity derivation failed");
+    unwrap_manifest_key(manifest, pk, sk, key);
+    encode_value(REVIEW_PREFIX, key, sizeof(key), review, sizeof(review));
+    printf("review_key=%s\n", review);
+    fclose(manifest);
+    sodium_memzero(sk, sizeof(sk));
+    sodium_memzero(key, sizeof(key));
+    sodium_memzero(token, sizeof(token));
+}
+
+static void decrypt_payload(FILE *in, const char *output_path, const unsigned char *key)
+{
+    crypto_secretstream_xchacha20poly1305_state state;
+    unsigned char magic[8], header[crypto_secretstream_xchacha20poly1305_HEADERBYTES];
+    unsigned char cipher[IO_CHUNK + crypto_secretstream_xchacha20poly1305_ABYTES];
+    unsigned char plain[IO_CHUNK];
+    unsigned long long plain_len;
+    unsigned char tag = 0;
+    FILE *verified = tmpfile();
+    FILE *out;
+    int saw_final = 0;
+
+    if (!verified)
+        die("failed to create verification buffer");
+    if (fread(magic, 1, sizeof(magic), in) != sizeof(magic) ||
+        memcmp(magic, PAYLOAD_MAGIC, sizeof(magic)) != 0 ||
+        fread(header, 1, sizeof(header), in) != sizeof(header) ||
+        crypto_secretstream_xchacha20poly1305_init_pull(&state, header, key) != 0)
+        die("invalid encrypted payload header");
+    for (;;) {
+        uint32_t cipher_len;
+        int rc = read_u32(in, &cipher_len);
+        if (rc == 0)
+            break;
+        if (rc < 0 || cipher_len < crypto_secretstream_xchacha20poly1305_ABYTES ||
+            cipher_len > sizeof(cipher) || fread(cipher, 1, cipher_len, in) != cipher_len)
+            die("invalid encrypted payload frame");
+        if (saw_final || crypto_secretstream_xchacha20poly1305_pull(
+                &state, plain, &plain_len, &tag, cipher, cipher_len, NULL, 0) != 0)
+            die("encrypted payload authentication failed");
+        if (write_all(verified, plain, (size_t)plain_len) != 0)
+            die("failed to buffer decrypted output");
+        if (tag == crypto_secretstream_xchacha20poly1305_TAG_FINAL)
+            saw_final = 1;
+        else if (tag != 0)
+            die("unsupported encrypted payload tag");
+    }
+    if (!saw_final)
+        die("encrypted payload is truncated");
+    rewind(verified);
+    out = fopen(output_path, "wb");
+    if (!out)
+        die("failed to create decrypted output");
+    for (;;) {
+        size_t n = fread(plain, 1, sizeof(plain), verified);
+        if (n > 0 && write_all(out, plain, n) != 0)
+            die("failed to write decrypted output");
+        if (n < sizeof(plain)) {
+            if (ferror(verified))
+                die("failed to read verified plaintext");
+            break;
+        }
+    }
+    if (fclose(verified) != 0 || fclose(out) != 0)
+        die("failed to finalize decrypted output");
+}
+
+static void command_decrypt(int argc, char **argv)
+{
+    const char *input = option_value(argc, argv, "--input");
+    const char *output = option_value(argc, argv, "--output");
+    int review_mode = has_option(argc, argv, "--review-key");
+    int stdin_mode = has_option(argc, argv, "--token-stdin");
+    struct tar_members members;
+    unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES];
+    char secret[TOKEN_MAX + 2];
+
+    if (!input || !output)
+        usage();
+    members = read_feedback_tar(input);
+    if (read_secret(review_mode ? "Review key: " : "Token: ", secret, sizeof(secret), stdin_mode) != 0)
+        die("failed to read decryption secret");
+    if (review_mode) {
+        if (decode_value(secret, REVIEW_PREFIX, key, sizeof(key)) != 0)
+            die("invalid review key");
+    } else {
+        unsigned char pk[crypto_box_PUBLICKEYBYTES], sk[crypto_box_SECRETKEYBYTES];
+        if (derive_keypair(secret, pk, sk) != 0)
+            die("invalid token or identity derivation failed");
+        unwrap_manifest_key(members.manifest, pk, sk, key);
+        sodium_memzero(sk, sizeof(sk));
+    }
+    decrypt_payload(members.payload, output, key);
+    fclose(members.payload);
+    fclose(members.manifest);
+    sodium_memzero(key, sizeof(key));
+    sodium_memzero(secret, sizeof(secret));
+}
+
+int main(int argc, char **argv)
+{
+    if (sodium_init() < 0)
+        die("libsodium initialization failed");
+    if (argc < 2)
+        usage();
+    if (strcmp(argv[1], "identity") == 0)
+        command_identity(argc, argv);
+    else if (strcmp(argv[1], "seal") == 0)
+        command_seal(argc, argv);
+    else if (strcmp(argv[1], "review-key") == 0)
+        command_review_key(argc, argv);
+    else if (strcmp(argv[1], "decrypt") == 0)
+        command_decrypt(argc, argv);
+    else
+        usage();
+    return 0;
+}

--- a/application/qmodem-seal/tests/test_qmodem_seal.sh
+++ b/application/qmodem-seal/tests/test_qmodem_seal.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+seal_bin=${1:-qmodem-seal}
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+token='Qm7vN2_xK9pR4tY8cW3d'
+wrong_token='WrongToken_8cW3d9pR4tY2'
+
+derive()
+{
+    printf '%s\n%s\n' "$1" "$1" | "$seal_bin" identity derive --token-stdin
+}
+
+derive "$token" > "$test_dir/id1"
+derive "$token" > "$test_dir/id2"
+cmp "$test_dir/id1" "$test_dir/id2"
+recipient=$(sed -n 's/^recipient=//p' "$test_dir/id1")
+[ -n "$recipient" ]
+
+printf 'fixture\000binary\r\nwith-tail\r\n\r\n' > "$test_dir/input.tar.gz"
+for n in 1 2; do
+    "$seal_bin" seal --recipient "$recipient" --input "$test_dir/input.tar.gz" \
+        --payload "$test_dir/payload$n.enc" --key "$test_dir/key$n.enc" > "$test_dir/review$n"
+done
+! cmp -s "$test_dir/payload1.enc" "$test_dir/payload2.enc"
+
+wrapped_key_hex=$(xxd -p "$test_dir/key1.enc" | tr -d '\n')
+jq -n --arg wrapped_key_hex "$wrapped_key_hex" \
+    '{format:"qmodem-feedback-v1",wrapped_key_hex:$wrapped_key_hex}' \
+    > "$test_dir/manifest.json"
+# The production archive uses fixed member names.
+mkdir "$test_dir/archive"
+cp "$test_dir/manifest.json" "$test_dir/archive/manifest.json"
+cp "$test_dir/payload1.enc" "$test_dir/archive/payload.enc"
+tar -cf "$test_dir/feedback.tar" -C "$test_dir/archive" manifest.json payload.enc
+
+review_key=$(sed -n 's/^review_key=//p' "$test_dir/review1")
+recovered_review=$(printf '%s\n' "$token" | "$seal_bin" review-key --token-stdin \
+    --manifest "$test_dir/manifest.json" | sed -n 's/^review_key=//p')
+[ "$review_key" = "$recovered_review" ]
+if printf '%s\n' "$wrong_token" | "$seal_bin" review-key --token-stdin \
+    --manifest "$test_dir/manifest.json" > "$test_dir/wrong-review" 2>/dev/null; then
+    echo 'wrong token unexpectedly recovered review key' >&2
+    exit 1
+fi
+[ ! -s "$test_dir/wrong-review" ]
+printf '%s\n' "$review_key" | "$seal_bin" decrypt --review-key --token-stdin \
+    --input "$test_dir/feedback.tar" --output "$test_dir/review.out"
+printf '%s\n' "$token" | "$seal_bin" decrypt --token-stdin \
+    --input "$test_dir/feedback.tar" --output "$test_dir/token.out"
+cmp "$test_dir/input.tar.gz" "$test_dir/review.out"
+cmp "$test_dir/input.tar.gz" "$test_dir/token.out"
+
+if printf '%s\n' "$wrong_token" | "$seal_bin" decrypt --token-stdin \
+    --input "$test_dir/feedback.tar" --output "$test_dir/wrong.out" 2>/dev/null; then
+    echo 'wrong token unexpectedly decrypted feedback' >&2
+    exit 1
+fi
+[ ! -e "$test_dir/wrong.out" ]
+
+cp "$test_dir/payload1.enc" "$test_dir/archive/payload.enc"
+printf '\001' | dd of="$test_dir/archive/payload.enc" bs=1 seek=40 conv=notrunc status=none
+tar -cf "$test_dir/tampered.tar" -C "$test_dir/archive" manifest.json payload.enc
+if printf '%s\n' "$review_key" | "$seal_bin" decrypt --review-key --token-stdin \
+    --input "$test_dir/tampered.tar" --output "$test_dir/tampered.out" 2>/dev/null; then
+    echo 'tampered feedback unexpectedly decrypted' >&2
+    exit 1
+fi
+[ ! -e "$test_dir/tampered.out" ]
+
+echo 'qmodem-seal tests passed'

--- a/application/qmodem/Makefile
+++ b/application/qmodem/Makefile
@@ -27,6 +27,7 @@ define Package/$(PKG_NAME)
 		+modem_scan \
 		+jq +bc\
 		+coreutils +coreutils-stat +xxd \
+		+PACKAGE_qmodem_INCLUDE_SEAL:qmodem-seal \
 		+usbutils \
 		+PACKAGE_luci-app-qmodem_INCLUDE_rdisc6:rdisc6 \
 		+PACKAGE_luci-app-qmodem_INCLUDE_ndisc6:ndisc6 \
@@ -50,6 +51,15 @@ define Package/$(PKG_NAME)
 		+PACKAGE_luci-app-qmodem_USE_TOM_CUSTOMIZED_QUECTEL_CM:quectel-CM-5G-M \
 		+PACKAGE_luci-app-qmodem_USING_QWRT_QUECTEL_CM_5G:quectel-CM-5G \
 		+PACKAGE_luci-app-qmodem_USING_NORMAL_QUECTEL_CM:quectel-cm
+endef
+
+define Package/$(PKG_NAME)/config
+	config PACKAGE_qmodem_INCLUDE_SEAL
+		bool "Include encrypted feedback support (qmodem-seal)"
+		default y
+		help
+		  Build and install qmodem-seal. When omitted, qmodem_collect
+		  falls back to an explicitly marked unencrypted archive.
 endef
 
 define Package/$(PKG_NAME)/description

--- a/application/qmodem/files/usr/sbin/qmodem_collect
+++ b/application/qmodem/files/usr/sbin/qmodem_collect
@@ -4,15 +4,28 @@
 # workflow:
 #   uci set qmodem.main.testcase_collect=1 && uci commit qmodem
 #   (exercise modem features via LuCI/ubus/CLI)
-#   qmodem_collect pack          # sanitized tarball in /tmp
-#   qmodem_collect pack --raw    # keep raw responses (may contain IMEI/IMSI/...)
+#   qmodem_collect pack                 # encrypted when qmodem-seal is available
+#   qmodem_collect pack --unencrypted   # explicitly create a plaintext tarball
+#   qmodem_collect pack --raw           # keep identifiers (still encrypted by default)
 # then scp the tarball off the device and run scripts/import_testcases.sh in the repo.
 
 COLLECT_DIR="${QMODEM_COLLECT_DIR:-/tmp/qmodem/testcases}"
+SEAL_CONFIG="${QMODEM_SEAL_CONFIG:-/usr/share/qmodem/feedback-recipient.conf}"
+PACK_PLAINTEXT=
+PACK_WORK=
+
+cleanup_pack()
+{
+    [ -z "$PACK_PLAINTEXT" ] || rm -f "$PACK_PLAINTEXT"
+    [ -z "$PACK_WORK" ] || rm -rf "$PACK_WORK"
+}
+
+trap cleanup_pack EXIT
+trap 'exit 1' HUP INT TERM
 
 usage()
 {
-    echo "usage: qmodem_collect <status|pack [--raw]|clear>" >&2
+    echo "usage: qmodem_collect <status|pack [--raw] [--unencrypted]|clear>" >&2
     exit 1
 }
 
@@ -40,6 +53,7 @@ mask_digits()
 
 cmd_status()
 {
+    local seal_bin recipient_id
     if collect_enabled; then
         echo "testcase_collect: on"
     else
@@ -49,6 +63,17 @@ cmd_status()
         echo "collect dir: $COLLECT_DIR ($(find "$COLLECT_DIR" -name '*.json' 2>/dev/null | wc -l) fixture files)"
     else
         echo "collect dir: $COLLECT_DIR (empty)"
+    fi
+    seal_bin="${QMODEM_SEAL_BIN:-qmodem-seal}"
+    if command -v "$seal_bin" >/dev/null 2>&1; then
+        recipient_id="${QMODEM_SEAL_RECIPIENT_ID:-$(sed -n 's/^recipient_id=//p' "$SEAL_CONFIG" 2>/dev/null | head -n 1)}"
+        if [ -n "$recipient_id" ]; then
+            echo "feedback encryption: ready ($recipient_id)"
+        else
+            echo "feedback encryption: qmodem-seal installed, recipient not configured"
+        fi
+    else
+        echo "feedback encryption: unavailable (pack falls back to plaintext)"
     fi
 }
 
@@ -60,14 +85,23 @@ cmd_clear()
 
 cmd_pack()
 {
-    local raw=0
-    [ "$1" = "--raw" ] && raw=1
+    local raw=0 unencrypted=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --raw) raw=1 ;;
+            --unencrypted) unencrypted=1 ;;
+            *) usage ;;
+        esac
+        shift
+    done
     [ -d "$COLLECT_DIR" ] || {
         echo "nothing collected in $COLLECT_DIR" >&2
         exit 1
     }
-    local work out_file file count
+    local work out_file file count timestamp inner_file seal_work seal_bin
+    local recipient recipient_id seal_output review_key wrapped_key_hex
     work=$(mktemp -d) || exit 1
+    PACK_WORK="$work"
     count=0
     #copy fixtures, sanitizing unless --raw
     for file in $(find "$COLLECT_DIR" -name '*.json' | sort); do
@@ -113,21 +147,97 @@ cmd_pack()
         fi
         count=$((count + 1))
     done
-    out_file="/tmp/qmodem_testcases_$(date +%Y%m%d_%H%M%S).tar.gz"
-    tar -czf "$out_file" -C "$work" . || {
+    timestamp=$(date +%Y%m%d_%H%M%S)
+    inner_file="/tmp/qmodem_testcases_${timestamp}.tar.gz"
+    PACK_PLAINTEXT="$inner_file"
+    tar -czf "$inner_file" -C "$work" . || {
         rm -rf "$work"
         echo "failed to create tarball" >&2
         exit 1
     }
     rm -rf "$work"
+    PACK_WORK=
     [ "$raw" = "1" ] || echo "sanitized: long digit sequences (including expected snapshots) are masked"
+
+    seal_bin="${QMODEM_SEAL_BIN:-qmodem-seal}"
+    if [ "$unencrypted" = "0" ] && ! command -v "$seal_bin" >/dev/null 2>&1; then
+        echo "WARNING: qmodem-seal is not installed; creating an UNENCRYPTED feedback archive" >&2
+        echo "WARNING: review the archive before uploading it" >&2
+        unencrypted=1
+    fi
+
+    if [ "$unencrypted" = "1" ]; then
+        out_file="$inner_file"
+        PACK_PLAINTEXT=
+        echo "encryption: OFF"
+        echo "packed $count fixture files -> $out_file"
+        echo "next: inspect the archive, then upload it to the testcase feedback issue"
+        return
+    fi
+
+    recipient="${QMODEM_SEAL_RECIPIENT:-$(sed -n 's/^recipient=//p' "$SEAL_CONFIG" 2>/dev/null | head -n 1)}"
+    recipient_id="${QMODEM_SEAL_RECIPIENT_ID:-$(sed -n 's/^recipient_id=//p' "$SEAL_CONFIG" 2>/dev/null | head -n 1)}"
+    [ -n "$recipient" ] || {
+        rm -f "$inner_file"
+        echo "qmodem-seal is installed but no feedback recipient is configured" >&2
+        echo "use --unencrypted only after reviewing the privacy warning" >&2
+        exit 1
+    }
+
+    seal_work=$(mktemp -d) || { rm -f "$inner_file"; exit 1; }
+    PACK_WORK="$seal_work"
+    seal_output=$("$seal_bin" seal --recipient "$recipient" --input "$inner_file" \
+        --payload "$seal_work/payload.enc" --key "$seal_work/key.enc") || {
+        rm -rf "$seal_work"
+        rm -f "$inner_file"
+        echo "failed to encrypt feedback archive" >&2
+        exit 1
+    }
+    review_key=$(printf '%s\n' "$seal_output" | sed -n 's/^review_key=//p')
+    [ -n "$review_key" ] || {
+        rm -rf "$seal_work"
+        rm -f "$inner_file"
+        echo "qmodem-seal did not return a review key" >&2
+        exit 1
+    }
+    wrapped_key_hex=$(xxd -p "$seal_work/key.enc" | tr -d '\n') || {
+        rm -rf "$seal_work"
+        rm -f "$inner_file"
+        echo "failed to encode wrapped feedback key" >&2
+        exit 1
+    }
+    jq -n --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg recipient_id "$recipient_id" --arg wrapped_key_hex "$wrapped_key_hex" \
+        --argjson sanitized "$([ "$raw" = 1 ] && echo false || echo true)" \
+        '{format:"qmodem-feedback-v1", encrypted:true, recipient_id:$recipient_id,
+          created_at:$created, sanitized:$sanitized, payload:"payload.enc",
+          wrapped_key_hex:$wrapped_key_hex}' \
+        > "$seal_work/manifest.json" || {
+        rm -rf "$seal_work"
+        rm -f "$inner_file"
+        exit 1
+    }
+    out_file="/tmp/qmodem_feedback_${timestamp}.tar"
+    tar -cf "$out_file" -C "$seal_work" manifest.json payload.enc || {
+        rm -rf "$seal_work"
+        rm -f "$inner_file"
+        echo "failed to create encrypted feedback package" >&2
+        exit 1
+    }
+    rm -rf "$seal_work"
+    PACK_WORK=
+    rm -f "$inner_file"
+    PACK_PLAINTEXT=
+    echo "encryption: ON ($recipient_id)"
     echo "packed $count fixture files -> $out_file"
-    echo "next: scp root@<device>:$out_file . && scripts/import_testcases.sh $out_file"
+    echo "review password/key (keep private): $review_key"
+    echo "verify: qmodem-seal decrypt --review-key --input $out_file --output /tmp/qmodem_review.tar.gz"
+    echo "upload only $out_file; do not post the review key"
 }
 
 case "$1" in
     status) cmd_status ;;
-    pack) cmd_pack "$2" ;;
+    pack) shift; cmd_pack "$@" ;;
     clear) cmd_clear ;;
     *) usage ;;
 esac

--- a/application/qmodem/files/usr/share/qmodem/feedback-recipient.conf
+++ b/application/qmodem/files/usr/share/qmodem/feedback-recipient.conf
@@ -1,4 +1,4 @@
 # Filled after the maintainer derives and publishes the release recipient.
 # Never place the recovery token or a private key in this file.
-recipient=
-recipient_id=
+recipient=qms1:98qR62JNVfHSD1rCdG5A2wdd-b5V-6lcB-yei1MMgzk
+recipient_id=qms1-3919e06fbbbff254

--- a/application/qmodem/files/usr/share/qmodem/feedback-recipient.conf
+++ b/application/qmodem/files/usr/share/qmodem/feedback-recipient.conf
@@ -1,0 +1,4 @@
+# Filled after the maintainer derives and publishes the release recipient.
+# Never place the recovery token or a private key in this file.
+recipient=
+recipient_id=

--- a/application/qmodem/tests/test_collect_encryption.sh
+++ b/application/qmodem/tests/test_collect_encryption.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+collect_bin="$PACKAGE_DIR/files/usr/sbin/qmodem_collect"
+seal_bin=${QMODEM_TEST_SEAL_BIN:-}
+test_dir=$(mktemp -d)
+plain_file=
+forced_plain_file=
+encrypted_file=
+cleanup()
+{
+    rm -rf "$test_dir"
+    [ -z "$plain_file" ] || rm -f "$plain_file"
+    [ -z "$forced_plain_file" ] || rm -f "$forced_plain_file"
+    [ -z "$encrypted_file" ] || rm -f "$encrypted_file"
+}
+trap cleanup EXIT
+
+mkdir -p "$test_dir/fixtures/quectel"
+response_hex=$(printf 'AT+CGSN\r\n861234567890123\r\nOK\r\n\r\n' | xxd -p | tr -d '\n')
+jq -n --arg h "$response_hex" \
+    '{vendor:"quectel",command:"AT+CGSN",response_hex:$h,tool:"at",rc:0}' \
+    > "$test_dir/fixtures/quectel/cgsn.json"
+
+plain_output=$(QMODEM_COLLECT_DIR="$test_dir/fixtures" \
+    QMODEM_SEAL_BIN=/not-installed/qmodem-seal "$collect_bin" pack 2>&1)
+printf '%s\n' "$plain_output" | grep -q 'UNENCRYPTED'
+printf '%s\n' "$plain_output" | grep -q 'encryption: OFF'
+plain_file=$(printf '%s\n' "$plain_output" | sed -n 's/.* -> //p')
+tar -tzf "$plain_file" | grep -q 'quectel/cgsn.json'
+
+# Encryption tests are skipped in generic shell-only CI unless a compiled
+# qmodem-seal is explicitly supplied.
+if [ -z "$seal_bin" ]; then
+    echo 'qmodem_collect plaintext fallback tests passed'
+    exit 0
+fi
+
+token='Qm7vN2_xK9pR4tY8cW3d'
+identity=$(printf '%s\n%s\n' "$token" "$token" | "$seal_bin" identity derive --token-stdin)
+recipient=$(printf '%s\n' "$identity" | sed -n 's/^recipient=//p')
+recipient_id=$(printf '%s\n' "$identity" | sed -n 's/^recipient_id=//p')
+encrypted_output=$(QMODEM_COLLECT_DIR="$test_dir/fixtures" QMODEM_SEAL_BIN="$seal_bin" \
+    QMODEM_SEAL_RECIPIENT="$recipient" QMODEM_SEAL_RECIPIENT_ID="$recipient_id" \
+    "$collect_bin" pack)
+printf '%s\n' "$encrypted_output" | grep -q 'encryption: ON'
+encrypted_file=$(printf '%s\n' "$encrypted_output" | sed -n 's/.* -> //p')
+review_key=$(printf '%s\n' "$encrypted_output" | sed -n 's/^review password\/key (keep private): //p')
+[ -n "$review_key" ]
+tar -tf "$encrypted_file" | grep -q '^manifest.json$'
+if tar -tf "$encrypted_file" | grep -q '^key.enc$'; then
+    echo 'wrapped key must be carried by manifest only' >&2
+    exit 1
+fi
+tar -xOf "$encrypted_file" manifest.json | jq -e \
+    --arg id "$recipient_id" \
+    '.encrypted == true and .sanitized == true and .recipient_id == $id and
+     (.wrapped_key_hex | type == "string" and length > 0)' >/dev/null
+tar -xOf "$encrypted_file" manifest.json > "$test_dir/manifest.json"
+owner_review=$(printf '%s\n' "$token" | "$seal_bin" review-key --token-stdin \
+    --manifest "$test_dir/manifest.json" | sed -n 's/^review_key=//p')
+[ "$review_key" = "$owner_review" ]
+printf '%s\n' "$review_key" | "$seal_bin" decrypt --review-key --token-stdin \
+    --input "$encrypted_file" --output "$test_dir/review.tar.gz"
+tar -xOzf "$test_dir/review.tar.gz" ./quectel/cgsn.json \
+    | jq -r '.response_hex' | xxd -r -p \
+    | cmp - <(printf 'AT+CGSN\r\n860000000000023\r\nOK\r\n\r\n')
+
+forced_output=$(QMODEM_COLLECT_DIR="$test_dir/fixtures" QMODEM_SEAL_BIN="$seal_bin" \
+    "$collect_bin" pack --unencrypted 2>&1)
+printf '%s\n' "$forced_output" | grep -q 'encryption: OFF'
+forced_plain_file=$(printf '%s\n' "$forced_output" | sed -n 's/.* -> //p')
+
+echo 'qmodem_collect encryption tests passed'

--- a/testcases/README.md
+++ b/testcases/README.md
@@ -39,14 +39,39 @@ testcases/
 uci set qmodem.main.testcase_collect=1 && uci commit qmodem
 # 通过 LuCI / ubus / CLI 触发各功能（base_info、cell_info、锁频、锁小区……）
 qmodem_collect status        # 查看已采集数量
-qmodem_collect pack          # 打包并脱敏到 /tmp/qmodem_testcases_<时间戳>.tar.gz
+qmodem_collect pack          # 默认脱敏并加密到 /tmp/qmodem_feedback_<时间戳>.tar
+qmodem_collect pack --unencrypted # 明确要求生成未加密 tar.gz
 qmodem_collect clear         # 清空采集目录（下一轮采集前）
 ```
+
+默认编译选项会安装 `qmodem-seal`。加密打包结束后会显示一个仅属于本次
+反馈的“审阅密码/密钥”（`review key`），提交者可用输出中的命令解密并检查
+内容。它是随机生成的高强度密钥，而不是要求用户记忆的密码。上传反馈包时
+不要同时公开该密钥。维护者使用未公开的 identity token 解密同一文件。
+
+反馈者应在提交前使用 review key 解密反馈包，确认其中只包含愿意公开的指令
+响应，并确认默认脱敏结果符合预期。加密用于保护公开传输和存储过程，不能
+代替反馈者自己的内容检查。反馈包中的数据可能被维护者选入仓库 testcase；
+正式合入前还会再次人工审阅和脱敏，但这也不能替代提交前检查。
+
+其他维护者需要处理反馈时，可只解压并把 `manifest.json` 发给 identity token
+持有者。token 持有者无需下载较大的 `payload.enc`，执行下列命令即可恢复该包
+的 review key，再通过私密渠道交给维护者：
+
+```sh
+qmodem-seal review-key --manifest manifest.json
+```
+
+如果固件编译时取消了 `qmodem-seal`，`pack` 会明确警告并回退到未加密
+tar.gz；请在上传前自行检查。`--unencrypted` 可在已安装加密组件时主动要求
+明文包。正式发布 recipient 尚未配置时，加密打包会拒绝执行，不会静默生成
+明文。
 
 开发机：
 
 ```sh
-scp root@<device>:/tmp/qmodem_testcases_*.tar.gz .
+scp root@<device>:/tmp/qmodem_feedback_*.tar .
+# 维护者先执行 qmodem-seal decrypt，得到 qmodem_testcases_*.tar.gz
 scripts/import_testcases.sh qmodem_testcases_*.tar.gz
 git add testcases && git commit
 ```


### PR DESCRIPTION
## 变更内容

- 新增可选且默认启用的 `qmodem-seal`，使用 libsodium 加密 fixture 反馈包
- 使用自定义 token 可重现派生维护者身份，固件只发布公钥
- `qmodem_collect pack` 默认加密；缺少可选组件时醒目警告并降级为明文
- 提交者获得每包随机 review key，可在上传前解密审阅脱敏结果
- 封装后的 review key 写入 manifest，token 持有者仅需 manifest 即可为其他维护者恢复 review key
- `--unencrypted` 明确选择未加密打包

## 验证

- qmodem-seal 编译启用 `-Wall -Wextra -Werror`
- 身份可重现、随机密文、review key/token 解密
- 错误 token、篡改和截断密文拒绝且不输出部分明文
- qmodem_collect 加密默认路径、缺包降级、显式明文和脱敏字节检查
- 原有 vendor cmds、core cmds、fixture 字节保真及回放测试

Closes no issue; Issue #236 将继续作为长期 testcase 征集入口。