### PR TITLE
ci: 修复 snapshot SDK 构建并升级到 3.2.0

### DIFF
--- a/.github/workflows/arm64_apk.env
+++ b/.github/workflows/arm64_apk.env
@@ -1,4 +1,4 @@
-SDK_NAME=openwrt-sdk-mvebu-cortexa53_gcc-14.3.0_musl.Linux-x86_64
+SDK_PREFIX=openwrt-sdk-mvebu-cortexa53_
 SDK_EXT=tar.zst
 SDK_URL=https://downloads.openwrt.org/snapshots/targets/mvebu/cortexa53/
 SDK_ARCH=aarch64_cortex-a53

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,7 @@ jobs:
   job_build_qmodem:
     name: Build QModem
     needs: [job_prepare]
+    if: ${{ always() && needs.job_prepare.result == 'success' }}
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,23 +185,52 @@ jobs:
       - name: Import Env
         run: cat qmodem/.github/workflows/${{ matrix.build_arch }}.env >> "$GITHUB_ENV"
 
+      - name: Resolve snapshot SDK
+        id: resolve-sdk
+        if: env.SDK_PREFIX != ''
+        run: |
+          wget -q "${SDK_URL}sha256sums" -O sdk-sha256sums
+          line=$(awk -v prefix="*${SDK_PREFIX}" -v suffix=".${SDK_EXT}" '
+            index($2, prefix) == 1 && substr($2, length($2) - length(suffix) + 1) == suffix {
+              match_line=$0
+              count++
+            }
+            END {
+              if (count != 1) {
+                print "expected one matching SDK, found " count > "/dev/stderr"
+                exit 1
+              }
+              print match_line
+            }
+          ' sdk-sha256sums)
+          sdk_sha256=${line%% *}
+          sdk_file=${line#* \*}
+          sdk_name=${sdk_file%.${SDK_EXT}}
+          echo "Resolved snapshot SDK: ${sdk_file}"
+          echo "SDK_NAME=${sdk_name}" >> "$GITHUB_ENV"
+          echo "SDK_SHA256=${sdk_sha256}" >> "$GITHUB_ENV"
+          echo "sdk_name=${sdk_name}" >> "$GITHUB_OUTPUT"
+
       - name: Cache openwrt SDK
         id: cache-sdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: sdk
-          key: openwrt-sdk-${{ matrix.build_arch }}
+          key: openwrt-sdk-${{ matrix.build_arch }}-${{ env.SDK_NAME }}${{ steps.resolve-sdk.outputs.sdk_name }}
 
       - name: Initialization environment
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         env:
           url_sdk: ${{ env.SDK_URL }}${{ env.SDK_NAME}}.${{ env.SDK_EXT }}
         run: |
-          wget ${{ env.url_sdk }}
-          file_name=${{ env.SDK_NAME}}.${{ env.SDK_EXT }}
-          if [ "${{ env.SDK_EXT }}" == "tar.zst" ]; then
+          file_name="${SDK_NAME}.${SDK_EXT}"
+          wget "${url_sdk}"
+          if [ -n "${SDK_SHA256:-}" ]; then
+            printf '%s  %s\n' "$SDK_SHA256" "$file_name" | sha256sum -c -
+          fi
+          if [ "${SDK_EXT}" == "tar.zst" ]; then
             mkdir sdk && tar --zstd -xvf $file_name -C ./sdk --strip-components=1
-          elif [ "${{ env.SDK_EXT }}" == "tar.xz" ]; then
+          elif [ "${SDK_EXT}" == "tar.xz" ]; then
             mkdir sdk && tar -xvf $file_name -C ./sdk --strip-components=1
           fi
           cd sdk

--- a/.github/workflows/mmips_apk.env
+++ b/.github/workflows/mmips_apk.env
@@ -1,4 +1,4 @@
-SDK_NAME=openwrt-sdk-ramips-mt7621_gcc-14.3.0_musl.Linux-x86_64
+SDK_PREFIX=openwrt-sdk-ramips-mt7621_
 SDK_EXT=tar.zst
 SDK_URL=https://downloads.openwrt.org/snapshots/targets/ramips/mt7621/
 SDK_ARCH=mipsel_24kc

--- a/.github/workflows/x64_apk.env
+++ b/.github/workflows/x64_apk.env
@@ -1,4 +1,4 @@
-SDK_NAME=openwrt-sdk-x86-64_gcc-14.3.0_musl.Linux-x86_64
+SDK_PREFIX=openwrt-sdk-x86-64_
 SDK_URL=https://downloads.openwrt.org/snapshots/targets/x86/64/
 SDK_ARCH=x86_64
 SDK_EXT=tar.zst

--- a/version.mk
+++ b/version.mk
@@ -21,5 +21,5 @@ endef
 QMODEM_COMMITCOUNT = $(if $(DUMP),0,$(call qmodem_commitcount))
 QMODEM_AUTORELEASE = $(if $(DUMP),0,$(call qmodem_commitcount,1))
 
-QMODEM_VERSION:=3.1.0
+QMODEM_VERSION:=3.2.0
 QMODEM_RELEASE:=$(QMODEM_AUTORELEASE)


### PR DESCRIPTION
## Summary

- resolve rolling OpenWrt snapshot SDK filenames from the official target sha256sums instead of pinning GCC 14.3.0
- require a unique SDK match, key caches by the resolved filename, and verify SHA-256 before extraction
- upgrade the SDK cache action to v4
- bump the unified QModem version from 3.1.0 to 3.2.0

## Root cause

The APK jobs requested GCC 14.3.0 SDK archives after OpenWrt snapshots had moved to GCC 14.4.0, so arm64_apk and mmips_apk failed during environment initialization with HTTP 404 before any QModem package compiled.

## Validation

The resolver was run against the official mvebu/cortexa53, ramips/mt7621, and x86/64 snapshot checksum indexes. Each target resolved exactly one current GCC 14.4.0 SDK. Workflow YAML parsing and git diff checks passed.
