### PR TITLE
fix(fibocom): read MediaTek carrier and parse CGPADDR IPv4

### DIFF
--- a/application/qmodem/files/usr/share/qmodem/cmds/fibocom.sh
+++ b/application/qmodem/files/usr/share/qmodem/cmds/fibocom.sh
@@ -114,6 +114,12 @@ cmd_cops_query()
     at "$1" "AT+COPS?"
 }
 
+#query current carrier (MediaTek)
+cmd_gtcurcar_query()
+{
+    at "$1" "AT+GTCURCAR?"
+}
+
 #query subscriber number
 cmd_cnum()
 {

--- a/application/qmodem/files/usr/share/qmodem/generic.sh
+++ b/application/qmodem/files/usr/share/qmodem/generic.sh
@@ -551,6 +551,14 @@ get_rat()
     echo "${rat}"
 }
 
+# Return the first usable quoted IPv4 address from AT+CGPADDR output.
+# FM350 reports IPv6 in dotted decimal notation after the IPv4 address.
+get_cgpaddr_ipv4()
+{
+    echo "$1" | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' \
+        | grep -v '^0\.0\.0\.0$' | head -n 1
+}
+
 #获取连接状态
 #return raw data
 get_connect_status()
@@ -588,12 +596,7 @@ get_connect_status()
             result=$(cmd_cgpaddr "$at_port" "$pdp_index" | grep $expect)
             if [ -n "$result" ];then
                 ipv6=$(echo $result | grep -oE "\b([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
-                ipv4=$(echo $result | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
-                disallow_ipv4="0.0.0.0"
-                #remove the disallow ip
-                if [ "$ipv4" == "$disallow_ipv4" ];then
-                    ipv4=""
-                fi
+                ipv4=$(get_cgpaddr_ipv4 "$result")
             fi
             if [ -n "$ipv4" ] || [ -n "$ipv6" ];then
                 connect_status="Yes"

--- a/application/qmodem/files/usr/share/qmodem/modem_dial.sh
+++ b/application/qmodem/files/usr/share/qmodem/modem_dial.sh
@@ -630,7 +630,7 @@ check_ip()
 
         if [ -n "$ipaddr" ];then
             ipv6=$(echo $ipaddr | grep -oE "\b([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
-            ipv4=$(echo $ipaddr | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
+            ipv4=$(get_cgpaddr_ipv4 "$ipaddr")
             if [ "$manufacturer" = "simcom" ];then
                 ipv4=$(echo $ipaddr | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | grep -v "0\.0\.0\.0" | head -n 1)
                 ipv6=$(echo $ipaddr | grep -oE "\b([0-9a-fA-F]{0,4}.){2,7}[0-9a-fA-F]{0,4}\b")
@@ -1512,7 +1512,7 @@ ip_change_fm350()
     else
         at_command="AT+CGPADDR=$pdp_index"
         response=$(cmd_dial_cgpaddr "$at_port" "$pdp_index")
-        ipv4_config=$(echo "$response" | grep "+CGPADDR:" | grep -o '"[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+"' | head -1 | tr -d '"')
+        ipv4_config=$(get_cgpaddr_ipv4 "$response")
         gateway="${ipv4_config%.*}.1"
 
         response=$(cmd_dial_gtdns "$at_port" "$pdp_index")

--- a/application/qmodem/files/usr/share/qmodem/vendor/fibocom.sh
+++ b/application/qmodem/files/usr/share/qmodem/vendor/fibocom.sh
@@ -757,6 +757,19 @@ base_info()
 # $1:SIM卡状态标志
 
 
+fibocom_get_carrier()
+{
+    local carrier
+
+    case "$platform" in
+        "mediatek")
+            carrier=$(cmd_gtcurcar_query "$at_port" | awk -F'"' '/^\+GTCURCAR:/ {print $2; exit}')
+            ;;
+    esac
+    [ -n "$carrier" ] || carrier=$(cmd_cops_query "$at_port" | grep "+COPS" | awk -F'"' '{print $2}')
+    echo "$carrier"
+}
+
 #SIM卡信息
 sim_info()
 {
@@ -780,7 +793,7 @@ sim_info()
     fi
 
     #ISP（互联网服务提供商）
-    isp=$(cmd_cops_query "$at_port" | grep "+COPS" | awk -F'"' '{print $2}')
+    isp=$(fibocom_get_carrier)
     # if [ "$isp" = "CHN-CMCC" ] || [ "$isp" = "CMCC" ]|| [ "$isp" = "46000" ]; then
     #     isp="中国移动"
     # elif [ "$isp" = "CHN-UNICOM" ] || [ "$isp" = "UNICOM" ] || [ "$isp" = "46001" ]; then

--- a/application/qmodem/tests/test_core_cmds.sh
+++ b/application/qmodem/tests/test_core_cmds.sh
@@ -4,6 +4,8 @@ set -eu
 
 PACKAGE_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 QMODEM_DIR="$PACKAGE_DIR/files/usr/share/qmodem"
+GENERIC_FILE="$QMODEM_DIR/generic.sh"
+FIBOCOM_FILE="$QMODEM_DIR/vendor/fibocom.sh"
 observed=
 
 at()
@@ -15,6 +17,7 @@ at()
 
 . "$QMODEM_DIR/cmds/modem_util.sh"
 . "$QMODEM_DIR/cmds/modem_dial.sh"
+. "$QMODEM_DIR/cmds/fibocom.sh"
 
 cmd_util_quimslot_query /dev/ttyUSB2
 [ "$observed_port" = /dev/ttyUSB2 ]
@@ -31,5 +34,32 @@ cmd_dial_command /dev/ttyUSB4 "$dynamic"
 
 cmd_dial_neoway_simcross_iccid /dev/ttyUSB5
 [ "$observed" = 'AT+SIMCROSS=1,1;$MYCCID' ]
+
+cmd_gtcurcar_query /dev/ttyUSB6
+[ "$observed_port" = /dev/ttyUSB6 ]
+[ "$observed" = 'AT+GTCURCAR?' ]
+
+get_function()
+{
+    awk -v name="$1" '
+        $0 == name "()" { capture = 1 }
+        capture { print }
+        capture && $0 == "}" { exit }
+    ' "$2"
+}
+
+eval "$(get_function get_cgpaddr_ipv4 "$GENERIC_FILE")"
+fm350_cgpaddr='+CGPADDR: 2,"10.3.4.136","0.0.0.0.0.0.0.0.24.141.77.91.197.17.80.76"'
+[ "$(get_cgpaddr_ipv4 "$fm350_cgpaddr")" = '10.3.4.136' ]
+[ -z "$(get_cgpaddr_ipv4 '+CGPADDR: 1,"0.0.0.0",""')" ]
+
+eval "$(get_function fibocom_get_carrier "$FIBOCOM_FILE")"
+platform=mediatek
+at_port=/dev/ttyUSB6
+cmd_gtcurcar_query() { printf '%s\n' '+GTCURCAR: 117,"China Telecom"'; }
+cmd_cops_query() { printf '%s\n' '+COPS: 0,2,"garbled",7'; }
+[ "$(fibocom_get_carrier)" = 'China Telecom' ]
+cmd_gtcurcar_query() { :; }
+[ "$(fibocom_get_carrier)" = 'garbled' ]
 
 echo 'core cmds tests passed'


### PR DESCRIPTION
Fixes part of #169.

- use AT+GTCURCAR? for Fibocom MediaTek carrier names, with AT+COPS? fallback
- parse only quoted, non-zero IPv4 values from AT+CGPADDR, avoiding FM350 dotted IPv6 values
- add command and parser regression coverage

Co-authored-by: @billtv

The PDP and DNS changes are intentionally excluded because they need a CID-aware solution and separate IPv6 DNS coverage.