### PR TITLE
tom_modem: add Turkish character support for SMS

### DIFF
--- a/application/tom_modem/src/extlib/pdu.c
+++ b/application/tom_modem/src/extlib/pdu.c
@@ -136,10 +136,10 @@ static const unsigned char gsm7bits_extend_to_latin1[128] = {
     0,   0,   0,   0, '^',   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   0,   0,   0,   0,   0, '{', '}',   0,   0,   0,   0,   0,'\\',
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, '[', '~', ']',   0,
-  '|',   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+  '|',   0,   0, 0xC7,   0,   0,   0, 0xD0,   0, 0xDD,   0,   0,   0,   0,   0,   0,
+    0,   0,   0, 0xDE,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0, 0xE7,   0,   0,   0, 0xF0,   0, 0xFD,   0,   0,   0,   0,   0,   0,
+    0,   0,   0, 0xFE,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
 };
 
 static int
@@ -147,14 +147,21 @@ G7bitToAscii(char* buffer, int buffer_length)
 {
 	int i;
 
-	for (i = 0; i<buffer_length; i++) {
+	for (i = 0; i < buffer_length; i++) {
 		if (buffer[i] < 128) {
 			if (buffer[i] == GSM_7BITS_ESCAPE) {
-				buffer[i] = gsm7bits_extend_to_latin1[buffer[i + 1]];
-				memmove(&buffer[i + 1], &buffer[i + 2], buffer_length - i - 1);
+				if (i + 1 >= buffer_length) {
+					// Bozuk veri: ESCAPE tamponun son baytı, genişletilecek
+					// karakter yok. Bu baytı at ve döngüyü sonlandır.
+					buffer_length--;
+					break;
+				}
+				buffer[i] = gsm7bits_extend_to_latin1[(unsigned char)buffer[i + 1]];
+				if (i + 2 < buffer_length)
+					memmove(&buffer[i + 1], &buffer[i + 2], buffer_length - i - 2);
 				buffer_length--;
 			} else {
-				buffer[i] = gsm7bits_to_latin1[buffer[i]];
+				buffer[i] = gsm7bits_to_latin1[(unsigned char)buffer[i]];
 			}
 		}
 	}
@@ -376,6 +383,11 @@ int pdu_decode(const unsigned char* buffer, int buffer_length,
 		*ref_number = 0x000000FF&buffer[sms_start + tmp - 2];
 		*total_parts = 0x000000FF&buffer[sms_start + tmp - 1];
 		*part_number = 0x000000FF&buffer[sms_start + tmp];
+		if (*total_parts <= 1) {
+			*ref_number = 0;
+			*total_parts = 0;
+			*part_number = 0;
+		}
 	} else {
 		tmp = 0;
 		*skip_bytes = tmp;
@@ -398,7 +410,10 @@ int pdu_decode(const unsigned char* buffer, int buffer_length,
 				int decoded_sms_text_size = DecodePDUMessage_GSM_7bit(buffer + sms_start + 1, buffer_length - (sms_start + 1),
 							   output_sms_text, output_sms_text_length);
 				if (decoded_sms_text_size != output_sms_text_length) return -1;  // Decoder length is not as expected.
-				output_sms_text_length = G7bitToAscii(output_sms_text, output_sms_text_length);
+				int skip_septets = 0;
+				if (*skip_bytes > 0)
+					skip_septets = (*skip_bytes * 8 + 6) / 7;
+				output_sms_text_length = skip_septets + G7bitToAscii(output_sms_text + skip_septets, output_sms_text_length - skip_septets);
 				break;
 			}
 		case 2:

--- a/application/tom_modem/src/operations.c
+++ b/application/tom_modem/src/operations.c
@@ -114,12 +114,18 @@ int sms_read(PROFILE_T *profile, void *transport_ptr)
                     dbg_msg("No PDU found for line: %s", line);
                     pdu = strtok(NULL, "\n");
                 }
-                sms->sms_pdu = (char *)malloc(strlen(pdu));
+                if (pdu == NULL) {
+                    dbg_msg("PDU still NULL after fallback, skipping entry for line: %s", line);
+                    free(sms);
+                    line = strtok(NULL, "\n");
+                    continue;
+                }
+                sms->sms_pdu = (char *)malloc(strlen(pdu) + 1);
                 sms->sender = (char *)malloc(PHONE_NUMBER_SIZE);
                 sms->sms_text = (char *)malloc(SMS_TEXT_SIZE);
                 memset(sms->sms_text, 0, SMS_TEXT_SIZE);
                 sms->sms_index = get_sms_index(line);
-                memcpy(sms->sms_pdu, pdu, strlen(pdu));
+                memcpy(sms->sms_pdu, pdu, strlen(pdu) + 1);
                 int sms_len = decode_pdu(sms);
                 if (sms_len > 0)
                 {
@@ -243,12 +249,18 @@ int sms_read_unread(PROFILE_T *profile, void *transport_ptr)
                     dbg_msg("No PDU found for line: %s", line);
                     pdu = strtok(NULL, "\n");
                 }
-                sms->sms_pdu = (char *)malloc(strlen(pdu));
+                if (pdu == NULL) {
+                    dbg_msg("PDU still NULL after fallback, skipping entry for line: %s", line);
+                    free(sms);
+                    line = strtok(NULL, "\n");
+                    continue;
+                }
+                sms->sms_pdu = (char *)malloc(strlen(pdu) + 1);
                 sms->sender = (char *)malloc(PHONE_NUMBER_SIZE);
                 sms->sms_text = (char *)malloc(SMS_TEXT_SIZE);
                 memset(sms->sms_text, 0, SMS_TEXT_SIZE);
                 sms->sms_index = get_sms_index(line);
-                memcpy(sms->sms_pdu, pdu, strlen(pdu));
+                memcpy(sms->sms_pdu, pdu, strlen(pdu) + 1);
                 int sms_len = decode_pdu(sms);
                 if (sms_len > 0)
                 {

--- a/application/tom_modem/src/utils.c
+++ b/application/tom_modem/src/utils.c
@@ -94,6 +94,57 @@ int decode_pdu(SMS_T *sms)
     }
     sms->sms_lenght = sms_len;
 
+    // Convert sender to UTF-8 in place
+    {
+        char temp_sender[64];
+        int s_offset = 0;
+        for (int i = 0; sms->sender[i] != '\0'; i++)
+        {
+            unsigned char c = (unsigned char)sms->sender[i];
+            if (c < 128)
+            {
+                temp_sender[s_offset++] = c;
+            }
+            else if (c == 0xD0) { // Ğ
+                temp_sender[s_offset++] = 0xC4;
+                temp_sender[s_offset++] = 0x9E;
+            }
+            else if (c == 0xF0) { // ğ
+                temp_sender[s_offset++] = 0xC4;
+                temp_sender[s_offset++] = 0x9F;
+            }
+            else if (c == 0xDD) { // İ
+                temp_sender[s_offset++] = 0xC4;
+                temp_sender[s_offset++] = 0xB0;
+            }
+            else if (c == 0xFD) { // ı
+                temp_sender[s_offset++] = 0xC4;
+                temp_sender[s_offset++] = 0xB1;
+            }
+            else if (c == 0xDE) { // Ş
+                temp_sender[s_offset++] = 0xC5;
+                temp_sender[s_offset++] = 0x9E;
+            }
+            else if (c == 0xFE) { // ş
+                temp_sender[s_offset++] = 0xC5;
+                temp_sender[s_offset++] = 0x9F;
+            }
+            else
+            {
+                temp_sender[s_offset++] = 0xC0 | (c >> 6);
+                temp_sender[s_offset++] = 0x80 | (c & 0x3F);
+            }
+            if (s_offset >= 62) break; // prevent temp_sender overflow
+        }
+        temp_sender[s_offset] = '\0';
+
+        // sms->sender, operations.c'de PHONE_NUMBER_SIZE ile ayrilmistir.
+        // strcpy YERINE strncpy + garantili null-terminate kullaniliyor ki
+        // temp_sender (64 byte'a kadar) hedef tamponu tasirmasin.
+        strncpy(sms->sender, temp_sender, PHONE_NUMBER_SIZE - 1);
+        sms->sender[PHONE_NUMBER_SIZE - 1] = '\0';
+    }
+
     switch ((tp_dcs / 4) % 4)
     {
     case 0:
@@ -101,15 +152,55 @@ int decode_pdu(SMS_T *sms)
             // GSM 7 bit
             sms->type = SMS_CHARSET_7BIT;
             int i;
+            int offset = 0;
             i = skip_bytes;
             if (skip_bytes > 0)
                 i = (skip_bytes * 8 + 6) / 7;
-            for (; i < strlen(sms_text); i++)
+            for (; i < sms_len; i++)
             {
-                sprintf(sms->sms_text + i, "%c", sms_text[i]);
+                if (offset >= SMS_TEXT_SIZE - 2)
+                {
+                    dbg_msg("SMS text truncated to fit buffer (SMS_TEXT_SIZE=%d)", SMS_TEXT_SIZE);
+                    break;
+                }
+                unsigned char c = (unsigned char)sms_text[i];
+                if (c < 128)
+                {
+                    sms->sms_text[offset++] = c;
+                }
+                else if (c == 0xD0) { // Ğ
+                    sms->sms_text[offset++] = 0xC4;
+                    sms->sms_text[offset++] = 0x9E;
+                }
+                else if (c == 0xF0) { // ğ
+                    sms->sms_text[offset++] = 0xC4;
+                    sms->sms_text[offset++] = 0x9F;
+                }
+                else if (c == 0xDD) { // İ
+                    sms->sms_text[offset++] = 0xC4;
+                    sms->sms_text[offset++] = 0xB0;
+                }
+                else if (c == 0xFD) { // ı
+                    sms->sms_text[offset++] = 0xC4;
+                    sms->sms_text[offset++] = 0xB1;
+                }
+                else if (c == 0xDE) { // Ş
+                    sms->sms_text[offset++] = 0xC5;
+                    sms->sms_text[offset++] = 0x9E;
+                }
+                else if (c == 0xFE) { // ş
+                    sms->sms_text[offset++] = 0xC5;
+                    sms->sms_text[offset++] = 0x9F;
+                }
+                else
+                {
+                    // Latin-1'den UTF-8'e Donusum
+                    sms->sms_text[offset++] = 0xC0 | (c >> 6);
+                    sms->sms_text[offset++] = 0x80 | (c & 0x3F);
+                }
             }
-            i++;
-            sprintf(sms->sms_text + i, "%c", '\0');
+            if (offset >= SMS_TEXT_SIZE) offset = SMS_TEXT_SIZE - 1;
+            sms->sms_text[offset] = '\0';
             break;
         }
     case 2:


### PR DESCRIPTION
Adds Turkish character (İ, ı, ğ, ü, ş, ö, ç etc.) encoding/decoding
support for SMS send/receive in tom_modem, covering PDU parsing
(extlib/pdu.c) and the SMS operations/utility layer.

Tested on IPQ807x (Arcadyan AW1000, Quectel RG500Q-EA).