### PR TITLE
fix(luci): apply network configuration changes

### DIFF
--- a/luci/luci-app-qmodem-next/htdocs/luci-static/resources/view/qmodem/network_config.js
+++ b/luci/luci-app-qmodem-next/htdocs/luci-static/resources/view/qmodem/network_config.js
@@ -1018,15 +1018,5 @@ return view.extend({
 				}, _('Confirm'))
 			])
 		]);
-	},
-
-	handleSaveApply: function(ev, mode) {
-		return this.handleSave(ev).then(function() {
-			return callInitAction('qmodem_network', 'reload');
-		});
-	},
-
-	handleSave: function(ev) {
-		return this.super('handleSave', arguments);
 	}
 });


### PR DESCRIPTION
## Summary

- restore LuCI's default Save & Apply flow on the QModem network page
- commit pending UCI changes before the registered `qmodem_network` reload trigger runs
- keep explicit start, stop, restart, enable, and disable actions unchanged

## Attribution

Patch and root-cause analysis contributed by @husky2017 in #252. The commit preserves the contributor as the Git author; the maintainer remains the committer.

## Verification

- `node --check luci/luci-app-qmodem-next/htdocs/luci-static/resources/view/qmodem/network_config.js`
- `git diff --check`
- i18n extraction produced no template changes
- confirmed the inherited LuCI `handleSaveApply()` calls `handleSave()` followed by `ui.changes.apply()`
- confirmed `ucitrack` maps `qmodem` changes to `qmodem_network`

Fixes #252